### PR TITLE
Resolve the issue preventing the '.cancel()' method from canceling scheduled pending intents in Android Alarm Manager.

### DIFF
--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -55,6 +55,7 @@ import static androidx.core.app.NotificationCompat.PRIORITY_MAX;
 import static androidx.core.app.NotificationCompat.PRIORITY_MIN;
 
 import de.appplant.cordova.plugin.notification.util.LaunchUtils;
+import de.appplant.cordova.plugin.localnotification.TriggerReceiver;
 
 /**
  * Wrapper class around OS notification class. Handles basic operations
@@ -304,7 +305,7 @@ public final class Notification {
             return;
 
         for (String action : actions) {
-            Intent intent = new Intent(action);
+            Intent intent = new Intent(context, TriggerReceiver.class).setAction(action).putExtra(Notification.EXTRA_ID, options.getId());
             PendingIntent pi = LaunchUtils.getBroadcastPendingIntent(context, intent);
             if (pi != null) {
                 getAlarmMgr().cancel(pi);

--- a/src/android/notification/util/LaunchUtils.java
+++ b/src/android/notification/util/LaunchUtils.java
@@ -11,6 +11,8 @@ import static android.content.Intent.FLAG_ACTIVITY_NEW_TASK;
 
 import java.util.Random;
 
+import de.appplant.cordova.plugin.notification.Notification;
+
 public final class LaunchUtils {
 
    private static final Random _random = new Random();
@@ -32,7 +34,7 @@ public final class LaunchUtils {
     }
 
     public static PendingIntent getBroadcastPendingIntent(Context context, Intent intent) {
-        return  PendingIntent.getBroadcast(context, getRandomCode(), intent, getIntentFlags());
+        return  PendingIntent.getBroadcast(context, intent.getIntExtra(Notification.EXTRA_ID, getRandomCode()), intent, getIntentFlags());
     }
 
     public static PendingIntent getActivityPendingIntent(Context context, Intent intent) {


### PR DESCRIPTION
I observed that in Android 12/13, when utilizing the .cancel() method, it fails to cancel the event within the alarm manager. As a result, the pending event persists and will be broadcasted as initially scheduled. Consequently, during broadcasting, if it coincides with another scheduled notification item (with the same id), it gets captured and gives the impression of triggering earlier than intended. However, in reality, this pertains to the old notification which hasn't been effectively cleared from the alarm manager.

How to reproduce:

 - schedule a notification e.g. 
```
cordova.plugins.notification.local.schedule({
    id: 110,
    title: 'Foo ',
    text: 'Bar',
    foreground: true,
    priority: 2,
    vibrate: true,
    trigger: {at: new Date(2023,7,15,11,51,0)},     // somewhere in a future
})
```

 - dump alarm via adb: ``` adb shell dumpsys alarm PACKAGE_NAME > alarm.log ```
 - check that the record exists as something  with tag=*walarm*:NOTIFICATION_ID110-2 as RTC_WAKEUP record
 - try to cancel it via ```cordova.plugins.notification.local.cancel(110)```
 - dump alarm again and you will see that the record is still there
 
Therefore, the solution is to depend on the requestCode of the PendingIntent.getBroadcast which is assigned to each scheduled item so the pending intent can be correctly found.


P.S. related also to https://github.com/katzer/cordova-plugin-local-notifications/issues/1701 (SamsungAlarmManager: !@too many alarms (500) registered from uid)